### PR TITLE
In order to make it compile

### DIFF
--- a/include/stats.h
+++ b/include/stats.h
@@ -16,7 +16,7 @@
         ATK,
         DEF,
         XP
-    } stat_field_t;
+    };
 
     typedef struct stats {
         int health;


### PR DESCRIPTION
This prevents from having multiple definitions of `stat_field_t`